### PR TITLE
Issue #15: add dtype/mismatch + coercion samples + Q1/Q3 + datetime format samples

### DIFF
--- a/core/schemas.py
+++ b/core/schemas.py
@@ -39,7 +39,7 @@ class ColumnProfile(BaseModel):
     name: str = Field(..., description="The name of the column in the dataframe.")
     inferred_type: str = Field(..., description="The inferred data type (e.g., 'Numeric', 'Categorical', 'Datetime').")
 
-    # --- Issue #15: profiler gap fixes (Optional / Non-breaking) ---
+    # Optional profiler gap-fix fields (optional / non-breaking)
     actual_dtype: Optional[str] = Field(
         None, description="Actual pandas dtype for the column (e.g., 'object', 'int64', 'float64', 'datetime64[ns]')."
     )

--- a/plugins/profiler.py
+++ b/plugins/profiler.py
@@ -615,7 +615,7 @@ def generate_profile(df: pd.DataFrame, detailed_profiler: bool = False, target_c
         inferred_type = _infer_type(series, s_nonnull=s_nonnull)
 
         # ------------------------------------------------------------------
-        # Issue #15: additional profiler signals (all optional / non-breaking)
+        # Optional profiler signals (optional / non-breaking)
         # ------------------------------------------------------------------
         actual_dtype = str(series.dtype)
 
@@ -681,12 +681,12 @@ def generate_profile(df: pd.DataFrame, detailed_profiler: bool = False, target_c
             # Count only inf values and coercion failures, NOT natural missing data.
             # AutoGluon handles NaN natively, so natural missingness is not a defect.
             coercion_failures = int(s_num.isna().sum()) - original_nan - inf_values
-            # Issue #15: percentiles (Q1/Q3)
+            # Percentiles (Q1/Q3) for numeric columns
             if s_num.notna().any():
                 q1 = _safe_float(s_num.quantile(0.25))
                 q3 = _safe_float(s_num.quantile(0.75))
 
-            # Issue #15: coercion failure count + samples (what bad values look like)
+            # Coercion failures: count + sample raw values
             coercion_failure_count = int(coercion_failures)
             try:
                 coerced_nonnull = pd.to_numeric(s_nonnull, errors="coerce")
@@ -711,7 +711,7 @@ def generate_profile(df: pd.DataFrame, detailed_profiler: bool = False, target_c
         if inferred_type == "Datetime":
             datetime_format_consistency, earliest_date, latest_date = _datetime_consistency(series)
 
-            # Issue #15: show competing datetime formats (samples)
+            # Datetime: sample competing raw formats
             if non_null > 0:
                 dt_strings = s_nonnull.astype(str)
                 try:
@@ -774,7 +774,7 @@ def generate_profile(df: pd.DataFrame, detailed_profiler: bool = False, target_c
                 dominant_pattern=dominant_pattern,
                 ydata_metrics=ydata_by_col.get(str(col)) if detailed_profiler else None,
 
-                # Issue #15 additions (all optional)
+                # Optional profiler additions (all optional)
                 actual_dtype=actual_dtype,
                 type_mismatch=type_mismatch,
                 coercion_failure_count=coercion_failure_count,


### PR DESCRIPTION
Closes #15

What changed (non-breaking / optional fields)

This PR enriches ColumnProfile with additional signals to help the investigator + codegen agents produce better cleaning logic:
	•	actual_dtype: actual pandas dtype (storage type)
	•	type_mismatch: inferred Numeric/Datetime but stored as object/string (strong TYPE_ERROR hint)
	•	coercion_failure_count: count of values that fail numeric/datetime coercion (excluding natural NaNs)
	•	coercion_failure_samples: 3–5 example raw values that failed coercion
	•	random_sample_values: 3–5 random non-null samples (more representative than top-frequent only)
	•	q1, q3: numeric percentiles for IQR reasoning
	•	datetime_format_samples: example competing datetime string formats when parsing consistency is low

Implementation notes
	•	Numeric coercion uses pd.to_numeric(errors="coerce") and samples failing raw values from the original non-null set.
	•	Datetime coercion uses pd.to_datetime(..., format="mixed", errors="coerce") with a safe fallback for older pandas.
	•	All values remain JSON-serializable via the existing JSON-safe conversion utilities.

Validation
	•	python3 -m py_compile core/schemas.py plugins/profiler.py
	•	Schema validation + json.dumps(profile) smoke tests on mixed-type columns (numeric strings + bad tokens, mixed datetime formats + invalid tokens).